### PR TITLE
Added support for Swift Package Manager

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version:5.0
+
+import PackageDescription
+
+let package = Package(
+    name: "LayoutExtension",
+    platforms: [
+        .iOS(.v9),
+    ],
+    products: [
+        .library(name: "LayoutExtension",
+                 targets: ["LayoutExtension"]),
+    ],
+    targets: [
+        .target(name: "LayoutExtension",
+                path: "LayoutExtension/Classes"),
+    ],
+    swiftLanguageVersions: [.v5]
+)

--- a/README.md
+++ b/README.md
@@ -17,16 +17,29 @@ Required deployment target is iOS >= 9.0
 
 ## Installation
 
-LayoutExtension is available through [CocoaPods](https://cocoapods.org). To install
-it, simply add the following line to your Podfile:
+### CocoaPods
+
+To install LayoutExtension through [CocoaPods](https://cocoapods.org), simply add the following line to your `Podfile`:
 
 ```ruby
 pod 'LayoutExtension'
 ```
 
+### Carthage
+
+To install LayoutExtension through [Carthage](https://github.com/Carthage/Carthage), simply specify it in your `Cartfile`:
+
+```ogdl
+github "abswift/LayoutExtension"
+```
+
+### Manually
+
+If you prefer not to use any of the aforementioned dependency managers, you can install LayoutExtension into your project manually by downloading or cloning the files into your project.
+
 ## Usage
 
-When using the library through [CocoaPods](https://cocoapods.org) then please import the library like follows:
+When using the library through a dependency manager make sure to import the library like so:
 
 ```swift
 import LayoutExtension

--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ To install LayoutExtension through [Carthage](https://github.com/Carthage/Cartha
 github "abswift/LayoutExtension"
 ```
 
+### Swift Package Manager
+
+To install LayoutExtension through [Swift Package Manager](https://swift.org/package-manager/), add it to the `dependencies` value of your `Package.swift`.
+
+```swift
+dependencies: [
+    .package(name: "LayoutExtension", url: "git@github.com:abswift/layout-extension.git", .upToNextMajor(from: "0.2.1"))
+]
+```
+
+Or via the `File > Swift Packages > Add Package Dependency…` menu item in Xcode.
+
 ### Manually
 
 If you prefer not to use any of the aforementioned dependency managers, you can install LayoutExtension into your project manually by downloading or cloning the files into your project.

--- a/README.md
+++ b/README.md
@@ -39,12 +39,6 @@ If you prefer not to use any of the aforementioned dependency managers, you can 
 
 ## Usage
 
-When using the library through a dependency manager make sure to import the library like so:
-
-```swift
-import LayoutExtension
-```
-
 Basic example:
 
 ```swift
@@ -53,6 +47,12 @@ self.view.addSubview(box) { subview in
     subview.height(50)
     subview.center()
 }
+```
+
+When using the library through a dependency manager make sure to import the library like so:
+
+```swift
+import LayoutExtension
 ```
 
 ## Syntax


### PR DESCRIPTION
This adds a Package.swift file for SPM support, it doesn't change the CocoaPods structure or impact CocoaPods in any way.

Once this PR is merged a **new version will need to be tagged** so SPM can work, otherwise there will be errors about missing a manifest when attempting to pull it in. I'd recommend `0.2.1` as I put in the README installation instructions.

I've also updated the README with Carthage and manual installation instructions, since in Slack you mentioned manual installation and I noticed the repo had the `_Pods.xcodeproj` alias which is there for Carthage.

